### PR TITLE
Fix missing print_data_example method in ListwiseDatasetProcessor

### DIFF
--- a/lambda_dpo/src/llamafactory/data/processor/listwise.py
+++ b/lambda_dpo/src/llamafactory/data/processor/listwise.py
@@ -101,3 +101,13 @@ class ListwiseDatasetProcessor(DatasetProcessor):
                 model_inputs["pi_target"].extend(examples["_pi_target"][i][dimension])  # +4
 
         return model_inputs
+
+    def print_data_example(self, example: dict[str, list[int]]) -> None:
+        """Print a listwise data example to stdout."""
+        valid_labels = list(filter(lambda x: x != IGNORE_INDEX, example["labels"]))
+        print("input_ids:\n{}".format(example["input_ids"]))
+        print("inputs:\n{}".format(self.tokenizer.decode(example["input_ids"], skip_special_tokens=False)))
+        print("label_ids:\n{}".format(example["labels"]))
+        print(f"labels:\n{self.tokenizer.decode(valid_labels, skip_special_tokens=False)}")
+        if "pi_target" in example:
+            print("pi_target:\n{}".format(example["pi_target"]))


### PR DESCRIPTION
## Summary
• Fixed TypeError in ListwiseDatasetProcessor by implementing the missing abstract method `print_data_example`
• Enables proper instantiation of the class and allows listwise tests to pass

## Bug Details
**Error**: `TypeError: Can't instantiate abstract class ListwiseDatasetProcessor without an implementation for abstract method 'print_data_example'`

**Root Cause**: The `ListwiseDatasetProcessor` class inherits from `DatasetProcessor` which defines `print_data_example` as an abstract method, but the implementation was missing.

**Fix**: Added the `print_data_example` method following the same pattern as other processors in the codebase (pairwise.py, feedback.py, etc.)

## Test plan
- [x] Run `python -m pytest tests/data/processor/test_listwise.py -v` - passes
- [x] Verify the method follows the same pattern as other processors
- [x] Confirm no regression in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)