### PR TITLE
feat: Add ListwiseDataCollatorWithPadding for lambda-weighted DPO

### DIFF
--- a/lambda_dpo/collator_output_example.txt
+++ b/lambda_dpo/collator_output_example.txt
@@ -1,0 +1,137 @@
+[INFO|tokenization_utils_base.py:2023] 2025-06-09 14:13:14,956 >> loading file tokenizer.json from cache at /Users/xiyaowang/.cache/huggingface/hub/models--llamafactory--tiny-random-Llama-3/snapshots/bf2a2e3bf199ad2ee96f02a3c00246c608db22a8/tokenizer.json
+[INFO|tokenization_utils_base.py:2023] 2025-06-09 14:13:14,956 >> loading file tokenizer.model from cache at None
+[INFO|tokenization_utils_base.py:2023] 2025-06-09 14:13:14,956 >> loading file added_tokens.json from cache at None
+[INFO|tokenization_utils_base.py:2023] 2025-06-09 14:13:14,956 >> loading file special_tokens_map.json from cache at /Users/xiyaowang/.cache/huggingface/hub/models--llamafactory--tiny-random-Llama-3/snapshots/bf2a2e3bf199ad2ee96f02a3c00246c608db22a8/special_tokens_map.json
+[INFO|tokenization_utils_base.py:2023] 2025-06-09 14:13:14,956 >> loading file tokenizer_config.json from cache at /Users/xiyaowang/.cache/huggingface/hub/models--llamafactory--tiny-random-Llama-3/snapshots/bf2a2e3bf199ad2ee96f02a3c00246c608db22a8/tokenizer_config.json
+[INFO|tokenization_utils_base.py:2023] 2025-06-09 14:13:14,957 >> loading file chat_template.jinja from cache at None
+[INFO|tokenization_utils_base.py:2299] 2025-06-09 14:13:15,113 >> Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
+[INFO|configuration_utils.py:698] 2025-06-09 14:13:15,891 >> loading configuration file config.json from cache at /Users/xiyaowang/.cache/huggingface/hub/models--llamafactory--tiny-random-Llama-3/snapshots/bf2a2e3bf199ad2ee96f02a3c00246c608db22a8/config.json
+[INFO|configuration_utils.py:770] 2025-06-09 14:13:15,898 >> Model config LlamaConfig {
+  "architectures": [
+    "LlamaForCausalLM"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "bos_token_id": 128000,
+  "eos_token_id": [
+    128001,
+    128008,
+    128009
+  ],
+  "head_dim": 4,
+  "hidden_act": "silu",
+  "hidden_size": 16,
+  "initializer_range": 0.02,
+  "intermediate_size": 64,
+  "max_position_embeddings": 131072,
+  "mlp_bias": false,
+  "model_type": "llama",
+  "num_attention_heads": 4,
+  "num_hidden_layers": 2,
+  "num_key_value_heads": 4,
+  "pretraining_tp": 1,
+  "rms_norm_eps": 1e-05,
+  "rope_scaling": {
+    "factor": 8.0,
+    "high_freq_factor": 4.0,
+    "low_freq_factor": 1.0,
+    "original_max_position_embeddings": 8192,
+    "rope_type": "llama3"
+  },
+  "rope_theta": 500000.0,
+  "tie_word_embeddings": false,
+  "torch_dtype": "float16",
+  "transformers_version": "4.52.3",
+  "use_cache": true,
+  "vocab_size": 128256
+}
+
+[INFO|tokenization_utils_base.py:2023] 2025-06-09 14:13:16,275 >> loading file tokenizer.json from cache at /Users/xiyaowang/.cache/huggingface/hub/models--llamafactory--tiny-random-Llama-3/snapshots/bf2a2e3bf199ad2ee96f02a3c00246c608db22a8/tokenizer.json
+[INFO|tokenization_utils_base.py:2023] 2025-06-09 14:13:16,275 >> loading file tokenizer.model from cache at None
+[INFO|tokenization_utils_base.py:2023] 2025-06-09 14:13:16,275 >> loading file added_tokens.json from cache at None
+[INFO|tokenization_utils_base.py:2023] 2025-06-09 14:13:16,276 >> loading file special_tokens_map.json from cache at /Users/xiyaowang/.cache/huggingface/hub/models--llamafactory--tiny-random-Llama-3/snapshots/bf2a2e3bf199ad2ee96f02a3c00246c608db22a8/special_tokens_map.json
+[INFO|tokenization_utils_base.py:2023] 2025-06-09 14:13:16,276 >> loading file tokenizer_config.json from cache at /Users/xiyaowang/.cache/huggingface/hub/models--llamafactory--tiny-random-Llama-3/snapshots/bf2a2e3bf199ad2ee96f02a3c00246c608db22a8/tokenizer_config.json
+[INFO|tokenization_utils_base.py:2023] 2025-06-09 14:13:16,276 >> loading file chat_template.jinja from cache at None
+[INFO|tokenization_utils_base.py:2299] 2025-06-09 14:13:16,431 >> Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
+[INFO|2025-06-09 14:13:16] llamafactory.data.template:143 >> Add pad token: <|eot_id|>
+[INFO|2025-06-09 14:13:16] llamafactory.data.template:143 >> Add <|eom_id|> to stop words.
+INPUT FEATURES:
+==================================================
+Feature 1:
+  input_ids: [128000, 128006, 882, 128007, 271, 3923, 374, 279, 6864, 315, 9822, 30, 128009, 128006, 78191, 128007, 271, 60704, 128009]
+  attention_mask: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+  labels: [-100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, 60704, 128009]
+  pi_target: 0.6439142598879724
+
+Feature 2:
+  input_ids: [128000, 128006, 882, 128007, 271, 3923, 374, 279, 6864, 315, 9822, 30, 128009, 128006, 78191, 128007, 271, 95509, 128009]
+  attention_mask: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+  labels: [-100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, 95509, 128009]
+  pi_target: 0.032058603280084995
+
+Feature 3:
+  input_ids: [128000, 128006, 882, 128007, 271, 3923, 374, 279, 6864, 315, 9822, 30, 128009, 128006, 78191, 128007, 271, 40672, 128009]
+  attention_mask: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+  labels: [-100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, 40672, 128009]
+  pi_target: 0.08714431874203259
+
+Feature 4:
+  input_ids: [128000, 128006, 882, 128007, 271, 3923, 374, 279, 6864, 315, 9822, 30, 128009, 128006, 78191, 128007, 271, 38136, 1907, 128009]
+  attention_mask: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+  labels: [-100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, -100, 38136, 1907, 128009]
+  pi_target: 0.23688281808991016
+
+COLLATOR OUTPUT:
+==================================================
+Output type: <class 'transformers.tokenization_utils_base.BatchEncoding'>
+Output keys: ['input_ids', 'attention_mask', 'labels', 'pi_target']
+
+input_ids:
+  Type: <class 'torch.Tensor'>
+  Shape: torch.Size([4, 20])
+  Dtype: torch.int64
+  Data: tensor([[128000, 128006,    882, 128007,    271,   3923,    374,    279,   6864,
+            315,   9822,     30, 128009, 128006,  78191, 128007,    271,  60704,
+         128009, 128009],
+        [128000, 128006,    882, 128007,    271,   3923,    374,    279,   6864,
+            315,   9822,     30, 128009, 128006,  78191, 128007,    271,  95509,
+         128009, 128009],
+        [128000, 128006,    882, 128007,    271,   3923,    374,    279,   6864,
+            315,   9822,     30, 128009, 128006,  78191, 128007,    271,  40672,
+         128009, 128009],
+        [128000, 128006,    882, 128007,    271,   3923,    374,    279,   6864,
+            315,   9822,     30, 128009, 128006,  78191, 128007,    271,  38136,
+           1907, 128009]])
+
+attention_mask:
+  Type: <class 'torch.Tensor'>
+  Shape: torch.Size([4, 20])
+  Dtype: torch.int64
+  Data: tensor([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+        [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+        [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+        [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]])
+
+labels:
+  Type: <class 'torch.Tensor'>
+  Shape: torch.Size([4, 20])
+  Dtype: torch.int64
+  Data: tensor([[  -100,   -100,   -100,   -100,   -100,   -100,   -100,   -100,   -100,
+           -100,   -100,   -100,   -100,   -100,   -100,   -100,   -100,  60704,
+         128009,   -100],
+        [  -100,   -100,   -100,   -100,   -100,   -100,   -100,   -100,   -100,
+           -100,   -100,   -100,   -100,   -100,   -100,   -100,   -100,  95509,
+         128009,   -100],
+        [  -100,   -100,   -100,   -100,   -100,   -100,   -100,   -100,   -100,
+           -100,   -100,   -100,   -100,   -100,   -100,   -100,   -100,  40672,
+         128009,   -100],
+        [  -100,   -100,   -100,   -100,   -100,   -100,   -100,   -100,   -100,
+           -100,   -100,   -100,   -100,   -100,   -100,   -100,   -100,  38136,
+           1907, 128009]])
+
+pi_target:
+  Type: <class 'torch.Tensor'>
+  Shape: torch.Size([4])
+  Dtype: torch.float32
+  Data: tensor([0.6439, 0.0321, 0.0871, 0.2369])
+

--- a/lambda_dpo/listwise_collator_tests.txt
+++ b/lambda_dpo/listwise_collator_tests.txt
@@ -1,0 +1,14 @@
+============================= test session starts ==============================
+platform darwin -- Python 3.12.7, pytest-8.4.0, pluggy-1.6.0 -- /opt/anaconda3/bin/python
+cachedir: .pytest_cache
+rootdir: /Users/xiyaowang/Documents/Projects/Research/Multi-Preference-Lambda-weighted-DPO/lambda_dpo
+configfile: pyproject.toml
+plugins: anyio-4.9.0, cov-6.1.1, asyncio-1.0.0
+asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 6 items / 3 deselected / 3 selected
+
+tests/data/test_collator.py::test_listwise_collator_basic PASSED         [ 33%]
+tests/data/test_collator.py::test_listwise_collator_validation PASSED    [ 66%]
+tests/data/test_collator.py::test_listwise_collator_with_real_data PASSED [100%]
+
+======================= 3 passed, 3 deselected in 7.33s ========================

--- a/lambda_dpo/src/llamafactory/data/__init__.py
+++ b/lambda_dpo/src/llamafactory/data/__init__.py
@@ -14,6 +14,7 @@
 
 from .collator import (
     KTODataCollatorWithPadding,
+    ListwiseDataCollatorWithPadding,
     MultiModalDataCollatorForSeq2Seq,
     PairwiseDataCollatorWithPadding,
     SFTDataCollatorWith4DAttentionMask,
@@ -26,6 +27,7 @@ from .template import TEMPLATES, Template, get_template_and_fix_tokenizer
 __all__ = [
     "TEMPLATES",
     "KTODataCollatorWithPadding",
+    "ListwiseDataCollatorWithPadding",
     "MultiModalDataCollatorForSeq2Seq",
     "PairwiseDataCollatorWithPadding",
     "Role",

--- a/lambda_dpo/tests/data/test_collator.py
+++ b/lambda_dpo/tests/data/test_collator.py
@@ -18,7 +18,7 @@ import torch
 from PIL import Image
 
 from llamafactory.data import get_template_and_fix_tokenizer
-from llamafactory.data.collator import MultiModalDataCollatorForSeq2Seq, prepare_4d_attention_mask
+from llamafactory.data.collator import ListwiseDataCollatorWithPadding, MultiModalDataCollatorForSeq2Seq, prepare_4d_attention_mask
 from llamafactory.extras.constants import IGNORE_INDEX
 from llamafactory.hparams import get_infer_args
 from llamafactory.model import load_tokenizer
@@ -150,3 +150,208 @@ def test_4d_attention_mask():
     )
     assert list(attention_mask_computed.size()) == [2, 1, 6, 6]
     assert torch.all(attention_mask_computed == attention_mask_expected)
+
+
+def test_listwise_collator_basic():
+    """Test basic functionality of ListwiseDataCollatorWithPadding."""
+    model_args, data_args, *_ = get_infer_args({"model_name_or_path": TINY_LLAMA3, "template": "default"})
+    tokenizer_module = load_tokenizer(model_args)
+    template = get_template_and_fix_tokenizer(tokenizer_module["tokenizer"], data_args)
+    data_collator = ListwiseDataCollatorWithPadding(
+        template=template,
+        pad_to_multiple_of=8,
+        label_pad_token_id=IGNORE_INDEX,
+        **tokenizer_module,
+    )
+    
+    p = tokenizer_module["tokenizer"].pad_token_id
+    q = IGNORE_INDEX
+    
+    # Create 4 examples representing responses to the same prompt (like the restructured dataset)
+    features = [
+        {
+            "input_ids": [0, 1, 2, 3, 4, 5],
+            "attention_mask": [1, 1, 1, 1, 1, 1],
+            "labels": [q, q, q, q, 4, 5],
+            "pi_target": 0.6,
+            "images": [],
+            "videos": [],
+            "audios": [],
+        },
+        {
+            "input_ids": [0, 1, 2, 3, 6],
+            "attention_mask": [1, 1, 1, 1, 1],
+            "labels": [q, q, q, q, 6],
+            "pi_target": 0.1,
+            "images": [],
+            "videos": [],
+            "audios": [],
+        },
+        {
+            "input_ids": [0, 1, 2, 3, 7],
+            "attention_mask": [1, 1, 1, 1, 1],
+            "labels": [q, q, q, q, 7],
+            "pi_target": 0.2,
+            "images": [],
+            "videos": [],
+            "audios": [],
+        },
+        {
+            "input_ids": [0, 1, 2, 3, 8, 9],
+            "attention_mask": [1, 1, 1, 1, 1, 1],
+            "labels": [q, q, q, q, 8, 9],
+            "pi_target": 0.1,
+            "images": [],
+            "videos": [],
+            "audios": [],
+        },
+    ]
+    
+    batch_input = data_collator(features)
+    
+    # Check basic structure
+    assert "input_ids" in batch_input
+    assert "attention_mask" in batch_input
+    assert "labels" in batch_input
+    assert "pi_target" in batch_input
+    
+    # Check shapes
+    assert batch_input["input_ids"].shape[0] == 4  # 4 examples
+    assert batch_input["attention_mask"].shape[0] == 4
+    assert batch_input["labels"].shape[0] == 4
+    assert batch_input["pi_target"].shape[0] == 4
+    
+    # Check pi_target values are preserved
+    expected_pi_targets = torch.tensor([0.6, 0.1, 0.2, 0.1], dtype=torch.float32)
+    assert torch.allclose(batch_input["pi_target"], expected_pi_targets)
+    
+    # Check padding (sequences should be padded to multiple of 8)
+    seq_len = batch_input["input_ids"].shape[1]
+    assert seq_len % 8 == 0
+    assert seq_len == 8  # Expected padded length
+    
+    # Check padding tokens
+    expected_input = torch.tensor([
+        [0, 1, 2, 3, 4, 5, p, p],
+        [0, 1, 2, 3, 6, p, p, p],
+        [0, 1, 2, 3, 7, p, p, p],
+        [0, 1, 2, 3, 8, 9, p, p],
+    ])
+    assert torch.equal(batch_input["input_ids"], expected_input)
+    
+    expected_attention = torch.tensor([
+        [1, 1, 1, 1, 1, 1, 0, 0],
+        [1, 1, 1, 1, 1, 0, 0, 0],
+        [1, 1, 1, 1, 1, 0, 0, 0],
+        [1, 1, 1, 1, 1, 1, 0, 0],
+    ])
+    assert torch.equal(batch_input["attention_mask"], expected_attention)
+    
+    expected_labels = torch.tensor([
+        [q, q, q, q, 4, 5, q, q],
+        [q, q, q, q, 6, q, q, q],
+        [q, q, q, q, 7, q, q, q],
+        [q, q, q, q, 8, 9, q, q],
+    ])
+    assert torch.equal(batch_input["labels"], expected_labels)
+
+
+def test_listwise_collator_validation():
+    """Test that ListwiseDataCollatorWithPadding validates group size."""
+    model_args, data_args, *_ = get_infer_args({"model_name_or_path": TINY_LLAMA3, "template": "default"})
+    tokenizer_module = load_tokenizer(model_args)
+    template = get_template_and_fix_tokenizer(tokenizer_module["tokenizer"], data_args)
+    data_collator = ListwiseDataCollatorWithPadding(
+        template=template,
+        **tokenizer_module,
+    )
+    
+    # Test with invalid number of examples (not multiple of 4)
+    features = [
+        {
+            "input_ids": [0, 1, 2],
+            "attention_mask": [1, 1, 1],
+            "labels": [-100, -100, 2],
+            "pi_target": 0.5,
+        },
+        {
+            "input_ids": [0, 1, 3],
+            "attention_mask": [1, 1, 1],
+            "labels": [-100, -100, 3],
+            "pi_target": 0.5,
+        },
+        # Only 2 examples instead of 4
+    ]
+    
+    try:
+        data_collator(features)
+        assert False, "Should have raised ValueError for non-multiple of 4"
+    except ValueError as e:
+        assert "groups of 4 examples" in str(e)
+
+
+def test_listwise_collator_with_real_data():
+    """Test ListwiseDataCollatorWithPadding with data format from restructured dataset."""
+    model_args, data_args, *_ = get_infer_args({"model_name_or_path": TINY_LLAMA3, "template": "llama3"})
+    tokenizer_module = load_tokenizer(model_args)
+    template = get_template_and_fix_tokenizer(tokenizer_module["tokenizer"], data_args)
+    data_collator = ListwiseDataCollatorWithPadding(
+        template=template,
+        pad_to_multiple_of=4,
+        label_pad_token_id=IGNORE_INDEX,
+        **tokenizer_module,
+    )
+    
+    # Simulated data similar to the restructured dataset file
+    features = [
+        {
+            "input_ids": [128000, 128006, 882, 128007, 271, 3923, 374, 279, 6864, 315, 9822, 30, 128009, 128006, 78191, 128007, 271, 60704, 128009],
+            "attention_mask": [1] * 19,
+            "labels": [-100] * 17 + [60704, 128009],
+            "pi_target": 0.6439142598879724,
+        },
+        {
+            "input_ids": [128000, 128006, 882, 128007, 271, 3923, 374, 279, 6864, 315, 9822, 30, 128009, 128006, 78191, 128007, 271, 95509, 128009],
+            "attention_mask": [1] * 19,
+            "labels": [-100] * 17 + [95509, 128009],
+            "pi_target": 0.032058603280084995,
+        },
+        {
+            "input_ids": [128000, 128006, 882, 128007, 271, 3923, 374, 279, 6864, 315, 9822, 30, 128009, 128006, 78191, 128007, 271, 40672, 128009],
+            "attention_mask": [1] * 19,
+            "labels": [-100] * 17 + [40672, 128009],
+            "pi_target": 0.08714431874203259,
+        },
+        {
+            "input_ids": [128000, 128006, 882, 128007, 271, 3923, 374, 279, 6864, 315, 9822, 30, 128009, 128006, 78191, 128007, 271, 38136, 1907, 128009],
+            "attention_mask": [1] * 20,  # Madrid has 2 tokens so 1 extra
+            "labels": [-100] * 17 + [38136, 1907, 128009],
+            "pi_target": 0.23688281808991016,
+        },
+    ]
+    
+    batch_input = data_collator(features)
+    
+    # Check basic structure
+    assert "input_ids" in batch_input
+    assert "attention_mask" in batch_input
+    assert "labels" in batch_input
+    assert "pi_target" in batch_input
+    
+    # Check that pi_target values sum to 1.0 (within tolerance)
+    pi_sum = batch_input["pi_target"].sum().item()
+    assert abs(pi_sum - 1.0) < 1e-6, f"Pi targets should sum to 1.0, got {pi_sum}"
+    
+    # Check that variable length sequences are handled (Madrid has 2 tokens vs others 1)
+    # All sequences should be padded to the same length
+    seq_lengths = batch_input["attention_mask"].sum(dim=1)
+    max_len = seq_lengths.max().item()
+    
+    # The longest sequence (Madrid) should determine the padded length
+    assert seq_lengths[3].item() == 20  # Madrid sequence
+    assert seq_lengths[0].item() == 19  # Other sequences
+    
+    # Check that sequences are properly padded to multiple of 4
+    padded_len = batch_input["input_ids"].shape[1]
+    assert padded_len % 4 == 0
+    assert padded_len >= max_len


### PR DESCRIPTION
Add specialized data collator for handling listwise preference data with groups of 4 responses per prompt and pi_target weights for lambda-weighted DPO training.

Features:
- Handles groups of 4 responses with pi_target weights
- Proper padding for variable response lengths
- Validates input structure (must be multiple of 4)
- Preserves lambda-weighted preference targets
- Compatible with existing multimodal features

Tests:
- Basic functionality with padding and pi_target preservation
- Input validation for group size requirements
- Real dataset format compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)