### PR TITLE
Fix dataset loader check for None

### DIFF
--- a/lambda_dpo/src/llamafactory/data/loader.py
+++ b/lambda_dpo/src/llamafactory/data/loader.py
@@ -241,10 +241,10 @@ def _get_dataset_processor(
 
     elif stage == "rm":
         # Check if this is a listwise dataset by examining the first example
-        if "_pi_target" in peeked_example.keys():
-          dataset_processor_class = ListwiseDatasetProcessor
+        if peeked_example is not None and "_pi_target" in peeked_example:
+            dataset_processor_class = ListwiseDatasetProcessor
         else:
-          dataset_processor_class = PairwiseDatasetProcessor
+            dataset_processor_class = PairwiseDatasetProcessor
     elif stage == "kto":
         dataset_processor_class = FeedbackDatasetProcessor
     else:


### PR DESCRIPTION
## Summary
- avoid AttributeError when dataset is empty by checking `peeked_example` before accessing keys

## Testing
- `python -m py_compile lambda_dpo/src/llamafactory/data/loader.py`
- `pytest -q lambda_dpo/tests` *(fails: ModuleNotFoundError: No module named 'datasets')*

------
https://chatgpt.com/codex/tasks/task_e_68484a00b8ec83318e169871d954ff43