### PR TITLE
Clarify listwise collator groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ llamafactory-cli train examples/train_lora/llama3_lora_dpo.yaml
 
 This repository uses a slightly modified version of **LlamaFactory**:
 
-- **ListwiseDataCollatorWithPadding** – pads batches of four responses while
-  preserving the `pi_target` weight of each response. It returns a
-  `BatchEncoding` with tensors `input_ids`, `attention_mask`, `labels` and
-  `pi_target`.
+- **ListwiseDataCollatorWithPadding** – pads batches composed of one or more
+  4-response groups while preserving the `pi_target` weight of each response. It
+  returns a `BatchEncoding` with tensors `input_ids`, `attention_mask`, `labels`
+  and `pi_target`.
 - **ListwiseDatasetProcessor** – flattens multi-response examples with
   preference vectors into tokenized lists. The output is a dictionary containing
   `input_ids`, `labels`, `attention_mask` and the normalized `pi_target` values
-  for every group of four responses.
+  for each group of four responses.
 - **UltrafeedbackDatasetConverter** – converts raw UltraFeedback data (an
   instruction plus several completions with ratings) into the standard format
   used by the processor. It produces fields such as `_prompt`, the per-dimension

--- a/lambda_dpo/src/llamafactory/data/collator.py
+++ b/lambda_dpo/src/llamafactory/data/collator.py
@@ -311,13 +311,14 @@ class KTODataCollatorWithPadding(MultiModalDataCollatorForSeq2Seq):
 @dataclass
 class ListwiseDataCollatorWithPadding(MultiModalDataCollatorForSeq2Seq):
     r"""Data collator for listwise data.
-    
-    Handles groups of 4 responses per prompt with pi_target weights for lambda-weighted DPO.
-    Maintains the grouping structure during batching to ensure proper training dynamics.
+
+    Each feature can include one or more groups of four responses. The collator
+    flattens these groups while keeping the ``pi_target`` weights aligned so that
+    lambda-weighted DPO training preserves the listwise structure.
     """
 
     def __call__(self, features: list[dict[str, Any]]) -> dict[str, "torch.Tensor"]:
-        r"""Pad listwise data while preserving 4-response groups."""
+        r"""Pad listwise data while preserving groups of four responses."""
 
         expanded_features = []
         pi_targets = []
@@ -326,7 +327,7 @@ class ListwiseDataCollatorWithPadding(MultiModalDataCollatorForSeq2Seq):
             group_len = len(feature["input_ids"])
             if group_len % 4 != 0:
                 raise ValueError(
-                    f"Listwise feature must contain groups of 4 responses, got {group_len}"
+                    f"Listwise feature must contain multiples of 4 responses, got {group_len}"
                 )
 
             for idx in range(group_len):

--- a/lambda_dpo/tests/data/test_collator.py
+++ b/lambda_dpo/tests/data/test_collator.py
@@ -268,7 +268,7 @@ def test_listwise_collator_validation():
         data_collator(features)
         assert False, "Should have raised ValueError for non-multiple of 4"
     except ValueError as e:
-        assert "groups of 4 responses" in str(e)
+        assert "multiples of 4 responses" in str(e)
 
 
 def test_listwise_collator_with_real_data():


### PR DESCRIPTION
## Summary
- clarify docstring that `ListwiseDataCollatorWithPadding` can handle multiple groups of four responses
- adjust validation error message to say "multiples of 4"
- update README to mention this flexibility
- update tests to look for new error text

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_685bd607bc8c83318a3604fd1f1279ea