### PR TITLE
Set uniform weights for lambda DPO

### DIFF
--- a/lambda_dpo/src/llamafactory/train/dpo/trainer.py
+++ b/lambda_dpo/src/llamafactory/train/dpo/trainer.py
@@ -334,7 +334,8 @@ class CustomDPOTrainer(DPOTrainer):
             loss = -(p * log_softmaxed).sum(dim=1).mean()
             listwise_losses.append(loss)
 
-        weights = torch.rand(4, device=input_ids.device)
+        num_pref = len(listwise_losses)
+        weights = torch.ones(num_pref, device=input_ids.device)
         weights /= weights.sum()
         final_loss = sum(w * l for w, l in zip(weights, listwise_losses))
 


### PR DESCRIPTION
## Summary
- adjust aggregation weights in Lambda DPO trainer to use a uniform distribution instead of random sampling

## Testing
- `pytest tests/data/processor/test_listwise.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685e6dd232dc833189b3de564c08f4c5