### PR TITLE
Add UltraFeedback DPO loss

### DIFF
--- a/lambda_dpo/src/llamafactory/train/dpo/trainer.py
+++ b/lambda_dpo/src/llamafactory/train/dpo/trainer.py
@@ -280,8 +280,9 @@ class CustomDPOTrainer(DPOTrainer):
         r"""Subclass and override to accept extra kwargs."""
         if self.loss_type == "lambda_dpo":
             return self._compute_lambda_dpo_loss(model, inputs, return_outputs)
-        else:
-            return super().compute_loss(model, inputs, return_outputs)
+        if self.loss_type == "dpo" and "pi_target" in inputs:
+            return self._compute_ultra_dpo_loss(model, inputs, return_outputs)
+        return super().compute_loss(model, inputs, return_outputs)
 
     def _compute_lambda_dpo_loss(self, model, inputs, return_outputs):
         input_ids = inputs["input_ids"]
@@ -341,6 +342,89 @@ class CustomDPOTrainer(DPOTrainer):
 
         if return_outputs:
             return final_loss, {"loss_components": listwise_losses}
+        return final_loss
+
+    def _compute_ultra_dpo_loss(self, model, inputs, return_outputs):
+        """Compute pairwise DPO loss for the UltraFeedback listwise dataset."""
+        input_ids = inputs["input_ids"]
+        attention_mask = inputs["attention_mask"]
+        labels = inputs["labels"]
+        pi_target = inputs["pi_target"]
+
+        B = input_ids.size(0) // 16
+        pi_target = pi_target.view(B, 4, 4)
+
+        best_idx_rel = pi_target.argmax(dim=2)
+        worst_idx_rel = pi_target.argmin(dim=2)
+        batch_offset = torch.arange(B, device=input_ids.device).view(B, 1) * 16
+        dim_offset = torch.arange(4, device=input_ids.device).view(1, 4) * 4
+        best_idx = batch_offset + dim_offset + best_idx_rel
+        worst_idx = batch_offset + dim_offset + worst_idx_rel
+
+        ordered = torch.stack(
+            [
+                best_idx[:, 0],
+                worst_idx[:, 0],
+                best_idx[:, 1],
+                worst_idx[:, 1],
+                best_idx[:, 2],
+                worst_idx[:, 2],
+                best_idx[:, 3],
+                worst_idx[:, 3],
+            ],
+            dim=1,
+        )
+        flat_indices = ordered.view(-1)
+
+        selected_ids = input_ids[flat_indices]
+        selected_mask = attention_mask[flat_indices]
+        selected_labels = labels[flat_indices]
+
+        chunk_size = self.lambda_dpo_chunk_size or selected_ids.size(0)
+
+        seq_log_probs_list = []
+        ref_seq_log_probs_list = []
+        for start in range(0, selected_ids.size(0), chunk_size):
+            end = start + chunk_size
+            chunk_ids = selected_ids[start:end]
+            chunk_mask = selected_mask[start:end]
+            chunk_labels = selected_labels[start:end]
+
+            logits = model(input_ids=chunk_ids, attention_mask=chunk_mask).logits
+            log_probs = F.log_softmax(logits[:, :-1], dim=-1)
+            labels_shifted = chunk_labels[:, 1:].clone()
+            mask = labels_shifted != self.label_pad_token_id
+            labels_shifted[labels_shifted == self.label_pad_token_id] = 0
+            label_log_probs = torch.gather(log_probs, dim=2, index=labels_shifted.unsqueeze(-1)).squeeze(-1)
+            seq_lp = (label_log_probs * mask).sum(dim=1) / mask.sum(dim=1)
+            seq_log_probs_list.append(seq_lp)
+
+            with torch.no_grad():
+                if self.finetuning_args.use_ref_model and self.ref_model is not None:
+                    ref_logits = self.ref_model(input_ids=chunk_ids, attention_mask=chunk_mask).logits
+                    ref_log_probs = F.log_softmax(ref_logits[:, :-1], dim=-1)
+                    ref_label_log_probs = torch.gather(ref_log_probs, dim=2, index=labels_shifted.unsqueeze(-1)).squeeze(-1)
+                    ref_lp = (ref_label_log_probs * mask).sum(dim=1) / mask.sum(dim=1)
+                else:
+                    ref_lp = torch.zeros_like(seq_lp)
+            ref_seq_log_probs_list.append(ref_lp)
+
+        seq_log_probs = torch.cat(seq_log_probs_list, dim=0).view(B, 8)
+        ref_seq_log_probs = torch.cat(ref_seq_log_probs_list, dim=0).view(B, 8)
+
+        policy_best = seq_log_probs[:, 0::2]
+        policy_worst = seq_log_probs[:, 1::2]
+        ref_best = ref_seq_log_probs[:, 0::2]
+        ref_worst = ref_seq_log_probs[:, 1::2]
+
+        pi_logratios = policy_best - policy_worst
+        ref_logratios = ref_best - ref_worst
+        logits = pi_logratios - ref_logratios
+        losses = -F.logsigmoid(self.beta * logits)
+
+        final_loss = losses.mean()
+        if return_outputs:
+            return final_loss, [losses]
         return final_loss
 
     @override


### PR DESCRIPTION
## Summary
- support `pref_loss=dpo` with listwise UltraFeedback data by selecting best and worst responses per dimension and computing a pairwise loss
- refine loss calculation to avoid processing unused responses

## Testing
- `ruff check src/llamafactory/train/dpo/trainer.py`
- `pytest -k ultrafeedback -q` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686545361320833185573c2f37b5b135