### PR TITLE
Fix EOS token replacement for Qwen tokenizer

### DIFF
--- a/lambda_dpo/src/llamafactory/data/template.py
+++ b/lambda_dpo/src/llamafactory/data/template.py
@@ -180,7 +180,8 @@ class Template:
                     tokenizer.eos_token = eos_token
                     num_added_tokens = 0
                 else:
-                    raise
+                    num_added_tokens = tokenizer.add_tokens([eos_token], special_tokens=False)
+                    tokenizer.eos_token = eos_token
             else:
                 raise
 


### PR DESCRIPTION
## Summary
- handle tokenizers that don't allow unknown special tokens by adding EOS token as a normal token

## Testing
- `pytest lambda_dpo/tests/data/test_loader.py::test_peek_first_example -q` *(fails: ModuleNotFoundError: No module named 'datasets')*

------
https://chatgpt.com/codex/tasks/task_e_686635ce4c048331a8046c166e3075f3