### PR TITLE
Gracefully handle token addition failures

### DIFF
--- a/lambda_dpo/src/llamafactory/data/template.py
+++ b/lambda_dpo/src/llamafactory/data/template.py
@@ -180,8 +180,15 @@ class Template:
                     tokenizer.eos_token = eos_token
                     num_added_tokens = 0
                 else:
-                    num_added_tokens = tokenizer.add_tokens([eos_token], special_tokens=False)
-                    tokenizer.eos_token = eos_token
+                    try:
+                        num_added_tokens = tokenizer.add_tokens([eos_token], special_tokens=False)
+                        tokenizer.eos_token = eos_token
+                    except ValueError as e2:
+                        logger.warning_rank0(
+                            f"Cannot add eos token due to tokenizer restrictions: {e2}"
+                        )
+                        tokenizer.eos_token = eos_token
+                        num_added_tokens = 0
             else:
                 raise
 


### PR DESCRIPTION
## Summary
- guard adding custom EOS tokens so it won't crash on tokenizers that disallow adding tokens

## Testing
- `python3 -m pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68663788cedc833190dc1f0395f1371d